### PR TITLE
fix: add API key check to optional email and firecrawl tools

### DIFF
--- a/mastra/tools/email-tool.ts
+++ b/mastra/tools/email-tool.ts
@@ -2,7 +2,13 @@ import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
 import { Resend } from "resend";
 
-const resend = new Resend(process.env.RESEND_API_KEY);
+const getResendClient = () => {
+  const apiKey = process.env.RESEND_API_KEY;
+  if (!apiKey) {
+    throw new Error("RESEND_API_KEY environment variable is not set. The email-tool is currently unavailable.");
+  }
+  return new Resend(apiKey);
+};
 
 const proposedEmailSchema = z.object({
   emailHandle: z.string(),
@@ -101,6 +107,7 @@ export const sendEmailTool = createTool({
 
     const { to, subject, body } = proposedEmail;
 
+    const resend = getResendClient();
     await resend.emails.send({
       from: "Assistant UI <onboarding@resend.dev>",
       to: [to],

--- a/mastra/tools/firecrawl-tool.ts
+++ b/mastra/tools/firecrawl-tool.ts
@@ -1,10 +1,14 @@
 import FirecrawlApp from '@mendable/firecrawl-js';
 import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
- 
-const firecrawl = new FirecrawlApp({
-    apiKey: process.env.FIRECRAWL_API_KEY
-});
+
+const getFirecrawlClient = () => {
+  const apiKey = process.env.FIRECRAWL_API_KEY;
+  if (!apiKey) {
+    throw new Error("FIRECRAWL_API_KEY environment variable is not set. The firecrawl-tool is currently unavailable.");
+  }
+  return new FirecrawlApp({ apiKey });
+};
 
 export const firecrawlTool = createTool({
   id: "crawl-website",
@@ -16,6 +20,7 @@ export const firecrawlTool = createTool({
     content: z.string().optional()
   }),
   execute: async ({ context, }) => {
+    const firecrawl = getFirecrawlClient();
     const scrapeResponse = await firecrawl.scrape(context.url, {
         formats: ['markdown'],
         includeTags: ['title', 'meta', 'h1', 'h2', 'h3', 'p'],


### PR DESCRIPTION
Introduced checks for optional environment variables in both email-tool and firecrawl-tool. If the respective API key is missing, an error is thrown to prevent crash.